### PR TITLE
Initialize affirmer-embed Fastify service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Server configuration
+PORT=3000
+HOST=0.0.0.0
+
+# Example tenant identifier for provisioning tokens
+DEFAULT_TENANT_ID=tenant_123

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store
+
+# Local environment files
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+
+RUN npm install --production || \
+    (if [ -f package-lock.json ]; then npm ci --production; else npm install --production; fi)
+
+COPY . .
+
+ENV NODE_ENV=production
+
+EXPOSE 3000
+
+CMD ["node", "src/server.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "affirmer-embed",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "affirmer-embed",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "fastify": "^4.26.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "affirmer-embed",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Affirmer embed service using Fastify.",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "fastify": "^4.26.2"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,11 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const config = {
+  host: process.env.HOST ?? '127.0.0.1',
+  port: Number.parseInt(process.env.PORT ?? '3000', 10),
+  defaultTenantId: process.env.DEFAULT_TENANT_ID ?? 'tenant_123'
+};
+
+export default config;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,113 @@
+import Fastify from 'fastify';
+import config from './config.js';
+
+const tenants = new Map();
+const videos = new Map();
+const provisioningTokens = new Map();
+
+function ensureTenant(tenantId, name = 'Default tenant') {
+  if (!tenants.has(tenantId)) {
+    tenants.set(tenantId, { id: tenantId, name, createdAt: new Date().toISOString() });
+  }
+  return tenants.get(tenantId);
+}
+
+function addVideo({ id, tenantId, title }) {
+  const tenant = ensureTenant(tenantId);
+  const record = {
+    id,
+    tenantId: tenant.id,
+    title,
+    createdAt: new Date().toISOString()
+  };
+  videos.set(id, record);
+  return record;
+}
+
+function createProvisioningToken(token, tenantId) {
+  const tenant = ensureTenant(tenantId);
+  const record = {
+    token,
+    tenantId: tenant.id,
+    createdAt: new Date().toISOString()
+  };
+  provisioningTokens.set(token, record);
+  return record;
+}
+
+ensureTenant(config.defaultTenantId, 'Default tenant');
+addVideo({ id: 'video_1', tenantId: config.defaultTenantId, title: 'Welcome to Affirmer' });
+createProvisioningToken('token_default', config.defaultTenantId);
+
+const app = Fastify({ logger: true });
+
+app.get('/health', async () => ({ status: 'ok' }));
+
+app.get('/tenants', async () => Array.from(tenants.values()));
+
+app.post('/tenants', async (request, reply) => {
+  const { id, name } = request.body ?? {};
+  if (!id || !name) {
+    return reply.code(400).send({ error: 'Tenant id and name are required.' });
+  }
+  if (tenants.has(id)) {
+    return reply.code(409).send({ error: 'Tenant already exists.' });
+  }
+  const tenant = ensureTenant(id, name);
+  return reply.code(201).send(tenant);
+});
+
+app.get('/tenants/:tenantId/videos', async (request, reply) => {
+  const { tenantId } = request.params;
+  if (!tenants.has(tenantId)) {
+    return reply.code(404).send({ error: 'Tenant not found.' });
+  }
+  const tenantVideos = Array.from(videos.values()).filter((video) => video.tenantId === tenantId);
+  return tenantVideos;
+});
+
+app.post('/tenants/:tenantId/videos', async (request, reply) => {
+  const { tenantId } = request.params;
+  const { id, title } = request.body ?? {};
+  if (!tenants.has(tenantId)) {
+    return reply.code(404).send({ error: 'Tenant not found.' });
+  }
+  if (!id || !title) {
+    return reply.code(400).send({ error: 'Video id and title are required.' });
+  }
+  if (videos.has(id)) {
+    return reply.code(409).send({ error: 'Video already exists.' });
+  }
+  const video = addVideo({ id, tenantId, title });
+  return reply.code(201).send(video);
+});
+
+app.get('/provisioning-tokens', async () => Array.from(provisioningTokens.values()));
+
+app.post('/provisioning-tokens', async (request, reply) => {
+  const { token, tenantId } = request.body ?? {};
+  if (!token || !tenantId) {
+    return reply.code(400).send({ error: 'Token and tenantId are required.' });
+  }
+  if (provisioningTokens.has(token)) {
+    return reply.code(409).send({ error: 'Token already exists.' });
+  }
+  const record = createProvisioningToken(token, tenantId);
+  return reply.code(201).send(record);
+});
+
+export async function start() {
+  try {
+    await app.listen({ port: config.port, host: config.host });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+  return app;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  start();
+}
+
+export default app;


### PR DESCRIPTION
## Summary
- scaffold the affirmer-embed Node.js project with ESM configuration and Fastify server entrypoint
- add in-memory stores for tenants, videos, and provisioning tokens with supporting REST endpoints
- provide Dockerfile, environment example, and npm scripts for local development and production start

## Testing
- ⚠️ `npm install` *(fails: 403 Forbidden from the npm registry in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d61ae830988328bb00aa124d129545